### PR TITLE
fix

### DIFF
--- a/src/SendGrid.php
+++ b/src/SendGrid.php
@@ -40,12 +40,12 @@ class SendGrid extends Mailer
 
         $body = [];
 
-        if (empty($htmlBody) === false) {
-            $body[] = new Content('text/html', $htmlBody);
-        }
-
         if (empty($textBody) === false) {
             $body[] = new Content('text/plain', $textBody);
+        }
+
+        if (empty($htmlBody) === false) {
+            $body[] = new Content('text/html', $htmlBody);
         }
 
         if (empty($body) === true) {


### PR DESCRIPTION
- fixed error occurring when trying to send an email with `text/html` content before
  `text/plain` content